### PR TITLE
add LimitNOFILE to service files

### DIFF
--- a/trojan_v2ray_install.sh
+++ b/trojan_v2ray_install.sh
@@ -1706,6 +1706,7 @@ ExecReload=/bin/kill -HUP \$MAINPID
 Restart=on-failure
 RestartSec=10
 RestartPreventExitStatus=23
+LimitNOFILE=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
在trojan-go的systemd模版中添加LimitNOFILE解决使用一段时间发生断连的情况
参考：
https://github.com/p4gefau1t/trojan-go/pull/313