### PR TITLE
Change kernel version from 5.10.72 to 5.10.75

### DIFF
--- a/install_kernel.sh
+++ b/install_kernel.sh
@@ -3232,7 +3232,7 @@ function start_menu(){
             installKernel
         ;;
         45 )
-            linuxKernelToInstallVersion="5.10.72"
+            linuxKernelToInstallVersion="5.10.75"
             installKernel
         ;;
         51 )


### PR DESCRIPTION
[官网](https://kernel.ubuntu.com/~kernel-ppa/mainline/)没有5.10.72版本了，导致从官方安装5.10内核（第45个选项，默认5.10.72）会什么都不安装而直接进入卸载内核界面。我更换到5.10.75的版本去了