### PR TITLE
Update trojan_v2ray_install.sh

### DIFF
--- a/trojan_v2ray_install.sh
+++ b/trojan_v2ray_install.sh
@@ -1997,7 +1997,7 @@ EOF
         cat > "${nginxConfigSiteConfPath}/v2rayssl_site.conf" <<-EOF
     server {
         listen 443 ssl http2;
-        listen [::]:443 http2;
+        listen [::]:443 ssl http2;
         server_name  $configSSLDomain;
 
         ssl_certificate       ${configSSLCertPath}/$configSSLCertFullchainFilename;
@@ -2071,7 +2071,7 @@ EOM
             read -r -d '' nginxConfigStreamOwnWebsiteInput << EOM
     server {
         listen 8000 ssl http2;
-        listen [::]:8000 http2;
+        listen [::]:8000 ssl http2;
         server_name  $configNginxSNIDomainWebsite;
 
         ssl_certificate       ${configNginxSNIDomainWebsiteCertPath}/$configSSLCertFullchainFilename;


### PR DESCRIPTION
fix nginx .conf for IPv6 ssl
#248 
真是被自己蠢爆了，排查了半天没发现是nginx配置IPv6后面没有 ssl 导致出现SSL错误。
想问下为何在ipv4监听后加了ssl 却没有在ipv6监听后面加？是有什么特殊意图吗？如果没有可以合并这个pull request